### PR TITLE
 adding the lombok version

### DIFF
--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -70,6 +70,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<version>1.18.22</version>
 			<optional>true</optional>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
The auth-service could not start because the dependecy lombok did not have its version explicity stated.